### PR TITLE
Fix redis-py-cluster requirements.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ requests==2.20.0
 coverage==4.0.3
 mock==1.0.1
 urllib3==1.22
-zc.buildout==2.12.1
+zc.buildout==2.12.2
 pep8==1.7.1
-redis-py-cluster==1.2.0
+redis-py-cluster==1.3.6
+redis==2.10.6


### PR DESCRIPTION
Related with https://github.com/Grokzen/redis-py-cluster/issues/294
